### PR TITLE
Preparat algoritme de seguiment de paret geomètric

### DIFF
--- a/src/rubot_control/launch/rubot_wall_follower_gm.launch
+++ b/src/rubot_control/launch/rubot_wall_follower_gm.launch
@@ -1,8 +1,8 @@
 <launch>
-  <arg name="world" default="wall.world"/> 
+  <arg name="world" default="maze1.world"/> 
   <arg name="model" default="gopigo3.urdf" />
-  <arg name="x_pos" default="0.0"/>
-  <arg name="y_pos" default="0.0"/>
+  <arg name="x_pos" default="0.1"/>
+  <arg name="y_pos" default="-0.9"/>
   <arg name="z_pos" default="0.0"/>
 
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
@@ -14,26 +14,24 @@
   <node pkg="gazebo_ros" type="spawn_model" name="spawn_urdf"
     args="-urdf -model gopigo3 -x $(arg x_pos) -y $(arg y_pos) -z $(arg z_pos) -param robot_description" />
 
-  <!-- send fake joint values -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
     <param name="use_gui" value="False"/>
   </node>
-  <!-- Combine joint values -->
+
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
-  <!-- Show in Rviz   -->
+
   <node name="rviz" pkg="rviz" type="rviz"  args="-d $(find rubot_control)/rviz/rubot_nav.rviz"/>
-  <!-- Wall follower Program   -->
-    <arg name="kp" default="5" />
-    <arg name="distance_reference" default="0.175" />
-    <arg name="lookahead_distance" default="0.3" />
-    <arg name="theta" default="50" />
-    <arg name="forward_speed" default="0.04" />
+
+  <arg name="kp" default="5" />
+  <arg name="distance_reference" default="0.175" />
+  <arg name="lookahead_distance" default="0.3" />
+  <arg name="theta" default="50" />
+  <arg name="forward_speed" default="0.04" />
   <node name="wall_follower_controller" pkg="rubot_control" type="rubot_wall_follower_gm.py" output="screen" >
         <param name="kp" value="$(arg kp)"/>
         <param name="distance_reference" value="$(arg distance_reference)"/>
         <param name="lookahead_distance" value="$(arg lookahead_distance)"/>
         <param name="theta" value="$(arg theta)"/>
         <param name="forward_speed" value="$(arg forward_speed)"/>
-  
   </node>
 </launch>

--- a/src/rubot_control/src/rubot_wall_follower_gm.py
+++ b/src/rubot_control/src/rubot_wall_follower_gm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import rospy
 import numpy as np

--- a/src/rubot_control/src/rubot_wall_follower_gm.py
+++ b/src/rubot_control/src/rubot_wall_follower_gm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import rospy
 import numpy as np
@@ -73,10 +73,20 @@ class WallFollower:
             self.__isScanRangesLengthCorrectionFactorCalculated = True
 
         # Obtenemos las mediciones de A y B y las guardamos en variables locales
-        A = scan.ranges[int((-90 + self.__unWrapAngle(self.__theta))
-                            * self.__scanRangesLengthCorrectionFactor)]
+        A = scan.ranges[int(round(self.__unWrapAngle(-90 + np.rad2deg(self.__theta)))) * self.__scanRangesLengthCorrectionFactor]
         B = scan.ranges[self.__unWrapAngle(-90) *
                         self.__scanRangesLengthCorrectionFactor]
+
+        rospy.loginfo_once('Ángulo derecha:\t%d, Ángulo theta:\t%d',
+            self.__unWrapAngle(-90) * self.__scanRangesLengthCorrectionFactor,
+            int(round(self.__unWrapAngle(-90 + np.rad2deg(self.__theta)))) * self.__scanRangesLengthCorrectionFactor)
+            
+        rospy.loginfo("Delante:\t%.2f, Atrás:\t%.2f, Izquierda:\t%.2f, Derecha:\t%.2f, Theta:\t%.2f",
+            scan.ranges[self.__unWrapAngle(0) * self.__scanRangesLengthCorrectionFactor],
+            scan.ranges[self.__unWrapAngle(180) * self.__scanRangesLengthCorrectionFactor],
+            scan.ranges[self.__unWrapAngle(90) * self.__scanRangesLengthCorrectionFactor],
+            scan.ranges[self.__unWrapAngle(-90) * self.__scanRangesLengthCorrectionFactor],
+            scan.ranges[int(round(self.__unWrapAngle(-90 + np.rad2deg(self.__theta)))) * self.__scanRangesLengthCorrectionFactor])
 
         # Si el valor leido de A no es NaN ni infinito y da entre 0.1 y 16 m (limites del Lidar),
         # actualizamos la propiedad self.__A con el nuevo valor


### PR DESCRIPTION
S'ha modificat l'algoritme per a convertir theta a graus a l'hora de seleccionar l'angle del LiDAR. També s'ha modificat el mapa del *launch file* perquè sigui el mateix que va fabricar en @manelpuig.

S'inclou un vídeo demostratiu de la velocitat amb els paràmetres del *launch file* per defecte. Cal prestar atenció a un moment en el qual el robot no fa bé el seguiment de paret. Es pot veure com una de les caixes no està ben col·locada sobre una de les parets. Modificant la seva posició, el robot segueix la paret perfectament (s'ha de modificar en el fitxer del mapa). Es pot jugar amb els paràmetres per fer que el robot recorri el mapa més de pressa (els paràmetres actuals són molts conservadors per tal de garantir el seu funcionament).

https://user-images.githubusercontent.com/83247762/141510120-344fb8e3-d36b-411d-a02c-8c4933a1c03b.mp4